### PR TITLE
Per service relying party IDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 target/
+
+.idea
+*.iml
+build

--- a/cas-server-support-wsfederation/README.md
+++ b/cas-server-support-wsfederation/README.md
@@ -6,3 +6,27 @@ See documentation at : https://github.com/Unicon/cas-adfs-integration/wiki
 
 #Versioning
 Version 1.0.0 works with CAS Server versions 3.5.1 through current (3.5.2).
+
+# Configurable Relying Party ID
+
+In previous versions, you would set a global relying party identifier for the system, such as in your properties file.
+This ID would be used for all services. Later versions, though, allow configuration of this ID per CAS service. If you
+use a service registry that supports `RegisteredServiceWithAttributes`, such as the JSON service registry from Unicon,
+you can add an extra attribute called `wsfed.relyingPartyId` to be used for that service
+
+For Example:
+
+```
+{
+    "services":[
+         {
+             "id": 2,
+             "serviceId": "https://**",
+             "name": "EVERY HTTPS",
+             "description": "allow all https",
+             "extraAttributes": {
+                "wsfed.relyingPartyId": "urn:federation:cas-mfa"
+             }
+         }
+    ]
+}

--- a/cas-server-support-wsfederation/README.md
+++ b/cas-server-support-wsfederation/README.md
@@ -30,3 +30,4 @@ For Example:
          }
     ]
 }
+```

--- a/cas-server-support-wsfederation/pom.xml
+++ b/cas-server-support-wsfederation/pom.xml
@@ -183,7 +183,7 @@
 					<target>${jdk.version}</target>
 				</configuration>
 			</plugin>
-
+<!--
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
@@ -211,7 +211,7 @@
 					</dependency>
 				</dependencies>
 			</plugin>
-
+-->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>

--- a/cas-server-support-wsfederation/src/main/java/net/unicon/cas/addons/serviceregistry/RegisteredServiceWithAttributes.java
+++ b/cas-server-support-wsfederation/src/main/java/net/unicon/cas/addons/serviceregistry/RegisteredServiceWithAttributes.java
@@ -1,0 +1,17 @@
+package net.unicon.cas.addons.serviceregistry;
+
+import org.jasig.cas.services.RegisteredService;
+
+import java.util.Map;
+
+/**
+ * An extention to <code>RegisteredService</code> with extra arbitrary attributes.
+ */
+public interface RegisteredServiceWithAttributes extends RegisteredService {
+    /**
+     * Extra attributes on the service.
+     *
+     * @return extraAttributes
+     */
+    Map<String, Object> getExtraAttributes();
+}

--- a/cas-server-support-wsfederation/src/main/java/net/unicon/cas/support/wsfederation/web/flow/WsFederationAction.java
+++ b/cas-server-support-wsfederation/src/main/java/net/unicon/cas/support/wsfederation/web/flow/WsFederationAction.java
@@ -114,6 +114,8 @@ public final class WsFederationAction extends AbstractAction {
 
                     } else {
                         logger.warn("SAML assertions are blank or no longer valid.");
+                        final String authorizationUrl = String.format("%s%s%s",this.configuration.getIdentityProviderUrl(), QUERYSTRING, this.getRelyingPartyIdentifier(service));
+                        context.getFlowScope().put(PROVIDERURL, authorizationUrl);
                         return error();
                     }
 

--- a/cas-server-support-wsfederation/src/main/java/net/unicon/cas/support/wsfederation/web/flow/WsFederationAction.java
+++ b/cas-server-support-wsfederation/src/main/java/net/unicon/cas/support/wsfederation/web/flow/WsFederationAction.java
@@ -16,6 +16,7 @@
 
 package net.unicon.cas.support.wsfederation.web.flow;
 
+import net.unicon.cas.addons.serviceregistry.RegisteredServiceWithAttributes;
 import net.unicon.cas.support.wsfederation.WsFederationConfiguration;
 import net.unicon.cas.support.wsfederation.WsFederationUtils;
 import net.unicon.cas.support.wsfederation.authentication.principal.WsFederationCredential;
@@ -24,6 +25,8 @@ import org.apache.commons.lang.StringUtils;
 import org.jasig.cas.CentralAuthenticationService;
 import org.jasig.cas.authentication.principal.Credentials;
 import org.jasig.cas.authentication.principal.Service;
+import org.jasig.cas.services.RegisteredService;
+import org.jasig.cas.services.ServicesManager;
 import org.jasig.cas.ticket.TicketException;
 import org.jasig.cas.web.support.WebUtils;
 import org.opensaml.saml1.core.impl.AssertionImpl;
@@ -63,6 +66,8 @@ public final class WsFederationAction extends AbstractAction {
     @NotNull
     private CentralAuthenticationService centralAuthenticationService;
 
+    private ServicesManager servicesManager;
+
     /**
      * Executes the webflow action.
      *
@@ -95,7 +100,8 @@ public final class WsFederationAction extends AbstractAction {
                     final WsFederationCredential credential = WsFederationUtils.createCredentialFromToken(assertion);
 
                     final Credentials credentials;
-                    if (credential != null && credential.isValid(configuration.getRelyingPartyIdentifier(),
+                    final Service service = (Service) session.getAttribute(SERVICE);
+                    if (credential != null && credential.isValid(getRelyingPartyIdentifier(service),
                             configuration.getIdentityProviderIdentifier(),
                             configuration.getTolerance())) {
 
@@ -113,7 +119,6 @@ public final class WsFederationAction extends AbstractAction {
 
                     // retrieve parameters from web session
                     try {
-                        final Service service = (Service) session.getAttribute(SERVICE);
                         context.getFlowScope().put(SERVICE, service);
                         restoreRequestAttribute(request, session, THEME);
                         restoreRequestAttribute(request, session, LOCALE);
@@ -153,10 +158,12 @@ public final class WsFederationAction extends AbstractAction {
                 saveRequestParameter(request, session, LOCALE);
                 saveRequestParameter(request, session, METHOD);
 
+                final String relyingPartyIdentifier = this.getRelyingPartyIdentifier(service);
+
                 final String key = PROVIDERURL;
                 final String authorizationUrl = this.configuration.getIdentityProviderUrl()
                         + QUERYSTRING
-                        + this.configuration.getRelyingPartyIdentifier();
+                        + relyingPartyIdentifier;
 
                 logger.debug("{} -> {}", key, authorizationUrl);
                 context.getFlowScope().put(key, authorizationUrl);
@@ -170,6 +177,26 @@ public final class WsFederationAction extends AbstractAction {
             return error();
         }
 
+    }
+
+    /**
+     * Get the relying party id for a service.
+     *
+     * @param service the service to get an id for
+     * @return relying party id
+     */
+    private String getRelyingPartyIdentifier(final Service service) {
+        String relyingPartyIdentifier = this.configuration.getRelyingPartyIdentifier();
+        if (service != null) {
+            final RegisteredService registeredService = this.servicesManager.findServiceBy(service);
+            if (registeredService instanceof RegisteredServiceWithAttributes
+                    && ((RegisteredServiceWithAttributes) registeredService).
+                    getExtraAttributes().containsKey("wsfed.relyingPartyId")) {
+                relyingPartyIdentifier = ((RegisteredServiceWithAttributes) registeredService).
+                        getExtraAttributes().get("wsfed.relyingPartyId").toString();
+            }
+        }
+        return relyingPartyIdentifier;
     }
 
     /**
@@ -214,5 +241,14 @@ public final class WsFederationAction extends AbstractAction {
      */
     public void setConfiguration(final WsFederationConfiguration configuration) {
         this.configuration = configuration;
+    }
+
+    /**
+     * set the services Manager.
+     *
+     * @param servicesManager the services manager
+     */
+    public void setServicesManager(final ServicesManager servicesManager) {
+        this.servicesManager = servicesManager;
     }
 }


### PR DESCRIPTION
This pull request adds support for per service relying party ID configuration. Configuration is controlled by the services registry as described in the README.md
